### PR TITLE
Allow credentials env vars instead of json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,30 @@ Or install it yourself as:
 
     $ gem install firebase_cloud_messenger
 
-In order for google to authenticate requests to Firebase Cloud Messenger, you must have your
-credentials file in a place that's accessible. You can tell firebase_cloud_messenger where it is in
-two ways:
+## Setup
+In order for google to authenticate requests to Firebase Cloud Messenger, you must either have your
+service account credentials file in a place that's accessible, or provide credentials as env vars.
 
-1. `FirebaseCloudMessenger.credentials_path = "path/to/credentials/file.json"`
-2. `export GOOGLE_APPLICATION_CREDENTIALS = "path/to/credentials/file.json"`
+#### Setup Method 1: Service Account JSON Path Supplied As Env Var
+```bash
+$ export GOOGLE_APPLICATION_CREDENTIALS = "path/to/credentials/file.json"`
+```
+
+#### Setup Method 2: Service Account JSON Path Supplied To FirebaseCloudMessenger
+```ruby
+FirebaseCloudMessenger.credentials_path = "path/to/credentials/file.json"
+```
+
+#### Setup Method 3: Service Account Credentials Set as Env Vars
+``` bash
+$ export GOOGLE_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----..."
+$ export GOOGLE_CLIENT_EMAIL = "firebase-admin-sdk...@iam.gserviceaccount.com"
+```
+Also set the `project_id`, which is otherwise read from the json service account file:
+
+```ruby
+FirebaseCloudMessenger.project_id = "1234567"
+```
 
 ## Usage
 

--- a/lib/firebase_cloud_messenger.rb
+++ b/lib/firebase_cloud_messenger.rb
@@ -15,16 +15,36 @@ require 'firebase_cloud_messenger/webpush'
 
 module FirebaseCloudMessenger
   class << self
-    attr_accessor :credentials_path
+    attr_accessor :credentials_path, :project_id
   end
 
   def self.send(message: {}, validate_only: false, conn: nil)
-    Client.new(credentials_path).send(message, validate_only, conn)
+    check_setup_complete!
+
+    Client.new(credentials_path, project_id).send(message, validate_only, conn)
   end
 
   def self.validate_message(message, conn = nil, against_api: false)
     message = Message.new(message) if message.is_a?(Hash)
 
     message.valid?(conn, against_api: against_api)
+  end
+
+  private
+
+  def self.check_setup_complete!
+    if !(credentials_path || project_id)
+      msg = <<-ERROR_MSG
+Either a credentials_path or project_id must be supplied. Add one of them like this:
+
+`FirebaseCloudMessenger.credentials_path = "path/to/credentials.json"`
+
+or:
+
+`FirebaseCloudMessenger.project_id = "12345678"`
+     ERROR_MSG
+
+     raise FirebaseCloudMessenger::SetupError, msg
+    end
   end
 end

--- a/lib/firebase_cloud_messenger/client.rb
+++ b/lib/firebase_cloud_messenger/client.rb
@@ -5,8 +5,13 @@ module FirebaseCloudMessenger
     attr_writer :max_retry_count, :project_id, :access_token
     attr_accessor :credentials_path
 
-    def initialize(credentials_path = nil)
+    def initialize(credentials_path = nil, project_id = nil)
       @credentials_path = credentials_path || ENV['GOOGLE_APPLICATION_CREDENTIALS']
+      @project_id = project_id
+
+      if !(@credentials_path || @project_id)
+        raise ArgumentError, "Either a project_id or a credentials_path must be supplied"
+      end
     end
 
     def send(message, validate_only, conn)

--- a/lib/firebase_cloud_messenger/error.rb
+++ b/lib/firebase_cloud_messenger/error.rb
@@ -1,4 +1,6 @@
 module FirebaseCloudMessenger
+  class SetupError < StandardError; end
+
   class Error < StandardError
     attr_reader :response
 

--- a/test/firebase_cloud_messenger_test.rb
+++ b/test/firebase_cloud_messenger_test.rb
@@ -2,6 +2,12 @@ require 'test_helper'
 
 class FirebaseCloudMessengerTest < MiniTest::Spec
   describe "::send" do
+    it "requires either a project_id or credentials_path" do
+      assert_raises FirebaseCloudMessenger::SetupError do
+        FirebaseCloudMessenger.send(message: { notification: { title: "title" } })
+      end
+    end
+
     it "creates a new instance of client and sends along the args" do
       msg = "Hello I am a message"
       validate_only = false
@@ -11,6 +17,8 @@ class FirebaseCloudMessengerTest < MiniTest::Spec
       mock_client.expects(:send).with(msg, validate_only, conn)
 
       FirebaseCloudMessenger::Client.expects(:new).returns(mock_client)
+
+      FirebaseCloudMessenger.project_id = "2"
 
       FirebaseCloudMessenger.send(message: msg, validate_only: validate_only, conn: conn)
     end

--- a/test/lib/firebase_cloud_messenger/auth_client_test.rb
+++ b/test/lib/firebase_cloud_messenger/auth_client_test.rb
@@ -1,8 +1,27 @@
 require 'test_helper'
 
 class FirebaseCloudMessenger::AuthClientTest < Minitest::Spec
+  describe "::new" do
+    it "throws an ArgumentError if credentials_path, client_email and private-key vars aren't set" do
+      ENV.stubs(:[]).with('GOOGLE_CLIENT_EMAIL').returns(nil)
+
+      assert_raises ArgumentError do
+        FirebaseCloudMessenger::AuthClient.new(nil)
+      end
+    end
+
+    it "throws no error if env vars are set" do
+      ENV.stubs(:[]).with('GOOGLE_PRIVATE_KEY').returns("1")
+      ENV.stubs(:[]).with('GOOGLE_CLIENT_EMAIL').returns("2")
+
+      Google::Auth::ServiceAccountCredentials.stubs(:make_creds)
+
+      FirebaseCloudMessenger::AuthClient.new(nil)
+    end
+  end
+
   describe "::fetch_access_token_info" do
-    it "calls out to the Google::Auth service and returns wrapped AccessTokenInfo" do
+    it "calls out to the Google::Auth service and returns access token info hash with creds file" do
       credentials_path = "path/to/credentials.json"
       authorizer = mock('authorizer')
       creds_file = mock('creds_file')
@@ -15,6 +34,21 @@ class FirebaseCloudMessenger::AuthClientTest < Minitest::Spec
       authorizer.expects(:fetch_access_token!).returns(token_response)
 
       access_token_info = FirebaseCloudMessenger::AuthClient.new(credentials_path).fetch_access_token_info
+
+      assert_equal "12345", access_token_info["access_token"]
+    end
+
+    it "calls out to the Google::Auth service and returns access token info with env vars" do
+      ENV.stubs(:[]).with('GOOGLE_PRIVATE_KEY').returns("1")
+      ENV.stubs(:[]).with('GOOGLE_CLIENT_EMAIL').returns("2")
+
+      authorizer = mock('authorizer')
+      token_response = { "access_token" => "12345", "token_type" => "Bearer", "expires_in" => "soon" }
+      authorizer.expects(:fetch_access_token!).returns(token_response)
+
+      Google::Auth::ServiceAccountCredentials.expects(:make_creds).with(scope: FirebaseCloudMessenger::AuthClient::AUTH_SCOPE).returns(authorizer)
+
+      access_token_info = FirebaseCloudMessenger::AuthClient.new.fetch_access_token_info
 
       assert_equal "12345", access_token_info["access_token"]
     end


### PR DESCRIPTION
`googleauth` requires _either_ a json service account file _or_ `GOOGLE_PRIVATE_KEY` and `GOOGLE_CLIENT_EMAIL` vars to be set. We should do the same to make env setup easier.

Since `project_id` is otherwise read off from the json, this allows it to be set in the necessary places.

Provides a nice, friendly error in the send method if setup is not completed.

Fixes #1