### PR TITLE
first attemped to read from a closed file

### DIFF
--- a/lib/firebase_cloud_messenger/auth_client.rb
+++ b/lib/firebase_cloud_messenger/auth_client.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module FirebaseCloudMessenger
   class AuthClient
     attr_reader :credentials_path
@@ -35,12 +37,8 @@ module FirebaseCloudMessenger
       args = { scope: AUTH_SCOPE }
       return args unless credentials_path
 
-      begin
-        file = File.open(credentials_path)
-        args.merge(json_key_io: file)
-      ensure
-        file.close
-      end
+      file =  Pathname.new(credentials_path)
+      args.merge(json_key_io: file)
     end
   end
 end


### PR DESCRIPTION
While sending a message I got:
```
IOError: closed stream
from /usr/local/rvm/gems/ruby-2.4.0/gems/googleauth-0.6.2/lib/googleauth/service_account.rb:75:in `read'
```

That was because the file was closed in an ensure-block. Instead passing a file you can just pass Pathname, which also respond to a read method