### PR TITLE
Add `NotFound` error for 404 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 0.3.0 - February 6, 2017
+* Adds `NotFound` error class and raises for 404 responses
+
 ## Version 0.2.1 - December 22, 2017
 * Fixes bug causing closed credentials file to be passed to the googleauth library. (Thanks to
   @tomek1024 for the patch.)

--- a/lib/firebase_cloud_messenger/error.rb
+++ b/lib/firebase_cloud_messenger/error.rb
@@ -11,6 +11,7 @@ module FirebaseCloudMessenger
               when 400 then FirebaseCloudMessenger::BadRequest
               when 401 then FirebaseCloudMessenger::Unauthorized
               when 403 then FirebaseCloudMessenger::Forbidden
+              when 404 then FirebaseCloudMessenger::NotFound
               else self
               end
 
@@ -55,4 +56,5 @@ module FirebaseCloudMessenger
   class BadRequest < Error; end
   class Unauthorized < Error; end
   class Forbidden < Error; end
+  class NotFound < Error; end
 end

--- a/lib/firebase_cloud_messenger/version.rb
+++ b/lib/firebase_cloud_messenger/version.rb
@@ -1,3 +1,3 @@
 module FirebaseCloudMessenger
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/test/lib/firebase_cloud_messenger/error_test.rb
+++ b/test/lib/firebase_cloud_messenger/error_test.rb
@@ -13,6 +13,10 @@ class FirebaseCloudMessenger::ErrorTest < MiniTest::Spec
     it "returns a Forbidden based on the response status" do
       assert_equal FirebaseCloudMessenger::Forbidden, FirebaseCloudMessenger::Error.from_response(mock_response("403")).class
     end
+
+    it "returns a NotFound based on the response status" do
+      assert_equal FirebaseCloudMessenger::NotFound, FirebaseCloudMessenger::Error.from_response(mock_response("404")).class
+    end
   end
 
   describe "#new" do


### PR DESCRIPTION
This is a common status code when users reinstall the app or are issued a new device token for some other reason and the server continues to try to send to the old token.