### PR TITLE
Add support for rich notifications in iOS (mutable-content APS parameter)

### DIFF
--- a/lib/firebase_cloud_messenger/apns/aps_dictionary.rb
+++ b/lib/firebase_cloud_messenger/apns/aps_dictionary.rb
@@ -1,7 +1,7 @@
 module FirebaseCloudMessenger
   module Apns
     class ApsDictionary < ApnsObject
-      FIELDS = %i(alert badge sound content_available category thread_id).freeze
+      FIELDS = %i(alert badge sound content_available mutable_content category thread_id).freeze
 
       attr_accessor(*FIELDS)
 

--- a/lib/firebase_cloud_messenger/schema.rb
+++ b/lib/firebase_cloud_messenger/schema.rb
@@ -100,6 +100,7 @@ module FirebaseCloudMessenger
           "badge"             => { "type" => "number" },
           "sound"             => { "type" => "string" },
           "content-available" => { "type" => "number" },
+          "mutable-content"   => { "type" => "number" },
           "category"          => { "type" => "string" },
           "thread-id"         => { "type" => "string" }
         },

--- a/test/lib/firebase_cloud_messenger/apns/aps_dictionary_test.rb
+++ b/test/lib/firebase_cloud_messenger/apns/aps_dictionary_test.rb
@@ -7,10 +7,11 @@ class FirebaseCloudMessenger::Apns::ApsDictionaryTest < MiniTest::Spec
                                                             badge: "badge",
                                                             sound: "sound",
                                                             content_available: "content_available",
+                                                            mutable_content: "mutable_content",
                                                             category: "category",
                                                             thread_id: "thread_id")
 
-      %i(alert badge sound content_available category thread_id).each do |field|
+      %i(alert badge sound content_available mutable_content category thread_id).each do |field|
         assert_equal field.to_s, msg.send(field)
       end
     end
@@ -28,10 +29,11 @@ class FirebaseCloudMessenger::Apns::ApsDictionaryTest < MiniTest::Spec
                                                             badge: "badge",
                                                             sound: "sound",
                                                             content_available: "content_available",
+                                                            mutable_content: "mutable_content",
                                                             category: "category",
                                                             thread_id: "thread_id")
 
-      expected = %i(alert badge sound content_available category thread_id).each_with_object({}) do |field, hash|
+      expected = %i(alert badge sound content_available mutable_content category thread_id).each_with_object({}) do |field, hash|
         hash[field.to_s.gsub("_", "-").to_sym] = field.to_s
       end
 


### PR DESCRIPTION
This parameter allows apps to alter the payload so they can create
a rich push notification with an image for example.

Documentation for said field can be found here:

https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ModifyingNotifications.html
https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension