### PR TITLE
Revert "Do not alter the original hash in FirebaseCloudMessenger::Message.new"

### DIFF
--- a/lib/firebase_cloud_messenger/message.rb
+++ b/lib/firebase_cloud_messenger/message.rb
@@ -9,7 +9,7 @@ module FirebaseCloudMessenger
     attr_writer :errors
 
     def initialize(data)
-      super(data.dup, FIELDS)
+      super(data, FIELDS)
     end
 
     def valid?(conn = nil, against_api: false)

--- a/test/lib/firebase_cloud_messenger/message_test.rb
+++ b/test/lib/firebase_cloud_messenger/message_test.rb
@@ -23,15 +23,6 @@ class FirebaseCloudMessenger::MessageTest < MiniTest::Spec
         FirebaseCloudMessenger::Message.new(foo: "foo")
       end
     end
-
-    it 'does not alter the original hash arg' do
-      hash = { name: 'name', data: 'data' }
-      duped_hash = hash.dup
-
-      FirebaseCloudMessenger::Message.new(hash)
-
-      assert_equal hash, duped_hash
-    end
   end
 
   describe "#to_h" do


### PR DESCRIPTION
Reverts patientslikeme/firebase_cloud_messenger#9