### PR TITLE
Fix issue #8

### DIFF
--- a/lib/firebase_cloud_messenger/firebase_object.rb
+++ b/lib/firebase_cloud_messenger/firebase_object.rb
@@ -1,6 +1,7 @@
 module FirebaseCloudMessenger
   class FirebaseObject
     def initialize(data, fields)
+      data = data.dup
       @fields = fields
 
       fields.each do |field|

--- a/test/lib/firebase_cloud_messenger/firebase_object_test.rb
+++ b/test/lib/firebase_cloud_messenger/firebase_object_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class FirebaseCloudMessenger::FirebaseObjectTest < MiniTest::Spec
+  FIELDS = %i(field1 field2)
+
+  class FireBaseObjectSubclass < FirebaseCloudMessenger::FirebaseObject
+    attr_accessor(*FIELDS)
+
+    def initialize(data)
+      super(data, FIELDS)
+    end
+  end
+
+  describe '#new' do
+    it 'throws an ArgumentError if key is not in fields' do
+      args = FIELDS.each_with_object({}) { |field, hash| hash[field] = true }.
+        merge(missing_key: true)
+
+      assert_raises ArgumentError do
+        FireBaseObjectSubclass.new(args)
+      end
+    end
+
+    it 'does not alter the original hash arg' do
+      args = FIELDS.each_with_object({}) { |field, hash| hash[field] = true }
+      duped_args = args.dup
+
+      FireBaseObjectSubclass.new(args)
+
+      assert_equal args, duped_args
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,4 +4,4 @@ require "firebase_cloud_messenger"
 require "minitest/autorun"
 require 'minitest/unit'
 require 'mocha'
-require 'mocha/mini_test'
+require 'mocha/minitest'


### PR DESCRIPTION
Since we cannot test `FirebaseObject` directly (no attr_accessors), we need to subclass it.
Instead of adding the spec to a random test file (or add it to all test files) that subclass it, I thought it would be best to create a class just for the testing purposes.

I also added a commit that is irrelevant to the PR, but it was quite small.

Let me know if you have any problem with the above or if you want me to open a separate PR for the 2nd commit.