### PR TITLE
Fix a typo in an exception message

### DIFF
--- a/lib/firebase_cloud_messenger/firebase_object.rb
+++ b/lib/firebase_cloud_messenger/firebase_object.rb
@@ -9,7 +9,7 @@ module FirebaseCloudMessenger
       end
 
       if data.any?
-        raise ArgumentError, "Keys must be one on #{fields.inspect}"
+        raise ArgumentError, "Keys must be one of #{fields.inspect}"
       end
     end
 


### PR DESCRIPTION
Seems like "on" was supposed to be "of" in the "Keys must be one on..." exception message.