### PR TITLE
Fix error handling example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ begin
   FirebaseCloudMessenger.send(message: message)
 rescue FirebaseCloudMessenger::Error => e
   e.class # => FirebaseCloudMessenger::BadRequest
-  e.message # => A message from fcm about what's wrong with the request
-  e.status # => 400
+  e.short_message # => A message from fcm about what's wrong with the request
+  e.response_status # => 400
   e.details # => An array of error details from fcm
 end
 ```


### PR DESCRIPTION
The error handling example in README is wrong: the [`Error`](https://github.com/patientslikeme/firebase_cloud_messenger/blob/aed8f0040a2b90f9a0b5d0c85678d7082cd3ab1f/lib/firebase_cloud_messenger/error.rb#L4) object doesn't have method `#status` and it should be `#response_status` instead.

The case for `#message` vs `#short_message` is not as clear, but since `#message` combines both `#}response_code`, `#short_message`, and `#details`, it seems the example should mention `#short_message`.