### PR TITLE
Add Android channel_id to schema

### DIFF
--- a/lib/firebase_cloud_messenger/schema.rb
+++ b/lib/firebase_cloud_messenger/schema.rb
@@ -28,17 +28,18 @@ module FirebaseCloudMessenger
       "android_notification" => {
         "type" => "object",
         "properties" => {
-          "title"          => { "type" => "string" },
-          "body"           => { "type" => "string" },
-          "icon"           => { "type" => "string" },
-          "color"          => { "type" => "string" },
-          "sound"          => { "type" => "string" },
-          "tag"            => { "type" => "string" },
-          "click_action"   => { "type" => "string" },
-          "body_loc_key"   => { "type" => "string" },
-          "body_loc_args"  => { "type" => "array", "items" => { "type" => "string" } },
-          "title_loc_key"  => { "type" => "string" },
-          "title_loc_args" => { "type" => "array", "items" => { "type" => "string" } }
+          "title"              => { "type" => "string" },
+          "body"               => { "type" => "string" },
+          "channel_id"         => { "type" => "string" },
+          "icon"               => { "type" => "string" },
+          "color"              => { "type" => "string" },
+          "sound"              => { "type" => "string" },
+          "tag"                => { "type" => "string" },
+          "click_action"       => { "type" => "string" },
+          "body_loc_key"       => { "type" => "string" },
+          "body_loc_args"      => { "type" => "array", "items" => { "type" => "string" } },
+          "title_loc_key"      => { "type" => "string" },
+          "title_loc_args"     => { "type" => "array", "items" => { "type" => "string" } }
         },
         "additionalProperties" => false
       },


### PR DESCRIPTION
Adds support to send the channel_id used by
Android Oreo and higher.

https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidnotification