### PR TITLE
Wrap timeout exceptions

### DIFF
--- a/lib/firebase_cloud_messenger/auth_client.rb
+++ b/lib/firebase_cloud_messenger/auth_client.rb
@@ -16,6 +16,10 @@ module FirebaseCloudMessenger
 
     def fetch_access_token_info
       authorizer.fetch_access_token!
+    rescue Faraday::ConnectionFailed
+      raise ConnectTimeout
+    rescue Faraday::TimeoutError
+      raise ReadTimeout
     end
 
     private

--- a/lib/firebase_cloud_messenger/client.rb
+++ b/lib/firebase_cloud_messenger/client.rb
@@ -88,6 +88,10 @@ module FirebaseCloudMessenger
       conn.post(send_url.path,
                 request_body(message, validate_only),
                 request_headers)
+    rescue Net::OpenTimeout
+      raise ConnectTimeout
+    rescue Net::ReadTimeout
+      raise ReadTimeout
     end
 
     def message_from_response(response)

--- a/lib/firebase_cloud_messenger/error.rb
+++ b/lib/firebase_cloud_messenger/error.rb
@@ -1,7 +1,8 @@
 module FirebaseCloudMessenger
-  class SetupError < StandardError; end
+  class BaseError < StandardError; end
+  class SetupError < BaseError; end
 
-  class Error < StandardError
+  class Error < BaseError
     attr_reader :response
 
     def self.from_response(response)
@@ -65,4 +66,8 @@ Details: #{details}
   class Unauthorized < Error; end
   class Forbidden < Error; end
   class NotFound < Error; end
+
+  class Timeout < BaseError; end
+  class ConnectTimeout < Timeout; end
+  class ReadTimeout < Timeout; end
 end

--- a/test/firebase_cloud_messenger_test.rb
+++ b/test/firebase_cloud_messenger_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class FirebaseCloudMessengerTest < MiniTest::Spec
   describe "::send" do
+    after do
+      FirebaseCloudMessenger.project_id = nil
+    end
+
     it "requires either a project_id or credentials_path" do
       assert_raises FirebaseCloudMessenger::SetupError do
         FirebaseCloudMessenger.send(message: { notification: { title: "title" } })

--- a/test/lib/firebase_cloud_messenger/client_test.rb
+++ b/test/lib/firebase_cloud_messenger/client_test.rb
@@ -78,7 +78,7 @@ class FirebaseCloudMessenger::ClientTest < MiniTest::Spec
       client.send(message, false, conn)
     end
 
-    it "wraps Net::OpenTimeout exceptions with the custom timeout classes" do
+    it "wraps Net::OpenTimeout exceptions with the custom timeout class" do
       client.access_token = "foo"
 
       conn = mock("request_conn")

--- a/test/lib/firebase_cloud_messenger/client_test.rb
+++ b/test/lib/firebase_cloud_messenger/client_test.rb
@@ -77,6 +77,28 @@ class FirebaseCloudMessenger::ClientTest < MiniTest::Spec
 
       client.send(message, false, conn)
     end
+
+    it "wraps Net::OpenTimeout exceptions with the custom timeout classes" do
+      client.access_token = "foo"
+
+      conn = mock("request_conn")
+      conn.expects(:post).raises(Net::OpenTimeout)
+
+      assert_raises(FirebaseCloudMessenger::ConnectTimeout) do
+        client.send(message_to_send, false, conn)
+      end
+    end
+
+    it "wraps Net::ReadTimeout exceptions with the custom timeout class" do
+      client.access_token = "foo"
+
+      conn = mock("request_conn")
+      conn.expects(:post).raises(Net::ReadTimeout)
+
+      assert_raises(FirebaseCloudMessenger::ReadTimeout) do
+        client.send(message_to_send, false, conn)
+      end
+    end
   end
 
   describe "access token fetching and refreshing" do


### PR DESCRIPTION
Hi,

We've been using Firebase Cloud Messenger and observed different behaviors in the wild. This PR is meant to help us simplify our own code for handling timeout errors from the various libraries. Currently, our rescue statement has to look like this:

```ruby
def send(notification)
  FirebaseCloudMessenger.send(message: notification)
rescue FirebaseCloudMessenger::Error => e
  # handle request errors
rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::ConnectionFailed, Faraday::TimeoutError => e
  # handle network-related errors
end
```

That second `rescue` line is really smelly and digs deep into the dependencies of Firebase Cloud Messenger, which we would like to avoid.

This PR reorganizes the exception hierarchy of the gem and fixes a flaky test which I encountered while working on this.